### PR TITLE
Update OAK Topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,50 @@
 # amiga-app-template
 
-This repository is designed to streamline the creation of a new application deployable to the Amiga brain.
+This repository is serve as reference to the Virtual Joystick app deployable to the Amiga Brain.
 
-For the most up-to-date documentation on using this template repository, please refer to:
+To learn more about building you own custom applications, please refer to:
 
 [amiga.farm-ng.com - **Developing Custom Applications**](https://amiga.farm-ng.com/docs/brain/brain-apps)
+
+> [!IMPORTANT]
+> This app will only work on Amiga Brains using v2.3+ of our OS. If you are not sure of which version you have, contact support@farm-ng.com 
+
+To install the Virtual Joystick App on your Amiga Brain, ssh into your robot and clone the repo to your user's home directory:
+
+```
+cd ~
+git clone https://github.com/farm-ng/virtual-joystick-v2.git
+```
+
+Remember to change `manifest.json` to point to your home directory:
+
+```
+{
+    "services": {
+        "virtual-joystick": {
+            "name": "virtual-joystick",
+            "type": "app",
+            "exec_cmd": "/mnt/managed_home/farm-ng-user-<YOUR-USERNAME-HERE>/virtual-joystick-v2/entry.sh",
+            "display_name": "Virtual Joystick"
+        }
+    }
+}
+```
+Now install the app using the script `install.sh`:
+
+```
+cd ~/virtual-joystick-v2
+./install.sh
+```
+
+You can now open the app on your Brain's launcher display or using:
+
+```
+./entry.sh
+```
+
+> [!NOTE]
+> The first time you run the App all dependencies will be installed, which may take a few minutes.
+
 
 ---

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To learn more about building you own custom applications, please refer to:
 [amiga.farm-ng.com - **Developing Custom Applications**](https://amiga.farm-ng.com/docs/brain/brain-apps)
 
 > [!IMPORTANT]
-> This app will only work on Amiga Brains using v2.3+ of our OS. If you are not sure of which version you have, contact support@farm-ng.com 
+> This app will only work on Amiga Brains using v2.3+ of our OS. If you are not sure of which version you have, contact support@farm-ng.com
 
 To install the Virtual Joystick App on your Amiga Brain, ssh into your robot and clone the repo to your user's home directory:
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
         "virtual-joystick": {
             "name": "virtual-joystick",
             "type": "app",
-            "exec_cmd": "/mnt/managed_home/farm-ng-user-oliverfuchs/virtual-joystick-v2/entry.sh",
+            "exec_cmd": "/mnt/managed_home/farm-ng-user-<USERNAME>/virtual-joystick-v2/entry.sh",
             "display_name": "Virtual Joystick"
         }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
         "virtual-joystick": {
             "name": "virtual-joystick",
             "type": "app",
-            "exec_cmd": "/mnt/managed_home/farm-ng-user-<USERNAME>/virtual-joystick-v2/entry.sh",
+            "exec_cmd": "/mnt/managed_home/farm-ng-user-marcelo/virtual-joystick-v2/entry.sh",
             "display_name": "Virtual Joystick"
         }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
         "virtual-joystick": {
             "name": "virtual-joystick",
             "type": "app",
-            "exec_cmd": "/mnt/managed_home/farm-ng-user-marcelo/virtual-joystick-v2/entry.sh",
+            "exec_cmd": "/mnt/managed_home/farm-ng-user-<USERNAME>/virtual-joystick-v2/entry.sh",
             "display_name": "Virtual Joystick"
         }
     }

--- a/service_config.json
+++ b/service_config.json
@@ -17,10 +17,6 @@
         "log_level": "INFO",
         "subscriptions": [
             {
-                "uri": {
-                    "path": "/rgb",
-                    "query": "service_name=oak0"
-                },
                 "every_n": 3
             }
         ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ install_requires =
     farm_ng_amiga
     kornia-rs
     PyTurboJPEG
+    protobuf==5.27.2
+    
 tests_require =
     pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     kornia-rs
     PyTurboJPEG
     protobuf==5.27.2
-    
+
 tests_require =
     pytest
 

--- a/src/main.py
+++ b/src/main.py
@@ -133,9 +133,10 @@ class KivyVirtualJoystick(App):
             await asyncio.sleep(0.01)
 
         rate = oak_client.config.subscriptions[0].every_n
+        uri = {"path":f'{oak_client.config.name}/{view_name}'} 
 
         async for event, payload in oak_client.subscribe(
-            SubscribeRequest(uri=Uri(path=f"/{view_name}"), every_n=rate),
+            SubscribeRequest(uri=uri, every_n=rate),
             decode=False,
         ):
 

--- a/src/main.py
+++ b/src/main.py
@@ -133,7 +133,7 @@ class KivyVirtualJoystick(App):
             await asyncio.sleep(0.01)
 
         rate = oak_client.config.subscriptions[0].every_n
-        uri = {"path":f'{oak_client.config.name}/{view_name}'} 
+        uri = {"path": f"{oak_client.config.name}/{view_name}"}
 
         async for event, payload in oak_client.subscribe(
             SubscribeRequest(uri=uri, every_n=rate),


### PR DESCRIPTION
Fixed the OAK topics that broken when amiga service was migrated to RUST
locked the protobuf version on 5.27.2 (last know stable as of today). Version 5.28+ introduced segmetation errors
Updated Readme.md for this repo. Previously was the kivy app's template.